### PR TITLE
Fix invalid export file reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.mjs",
+      "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }
   },


### PR DESCRIPTION
### Problem

Using the library in an ESM project causes an error because the `exports['.'].import` field in `package.json` refers to `dist/esm/index.mjs`, which does not exist. The `main` field, however, references `dist/esm/index.js` correctly.

### Solution

Update `exports['.'].import` value to match `main` and use the `.js` extension.